### PR TITLE
libs2e: added libgomp dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ set(LIBS ${LIBS} ${VMI_LIBRARY_DIR}/libvmi.a memcached lua ${LLVM_LIBS} z3 ${FSI
 set(LIBS ${LIBS} boost_serialization boost_system boost_regex)
 endif()
 
-set(LIBS ${LIBS} ${LIBCOROUTINE_LIBRARY_DIR}/libcoroutine.a pthread glib-2.0 bsd)
+set(LIBS ${LIBS} ${LIBCOROUTINE_LIBRARY_DIR}/libcoroutine.a pthread glib-2.0 gomp bsd)
 
 
 


### PR DESCRIPTION
This is used by Z3.

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>