### PR TITLE
Store apic state in cpu state instead of global variable

### DIFF
--- a/src/s2e-kvm-interface.h
+++ b/src/s2e-kvm-interface.h
@@ -42,9 +42,6 @@ extern int g_kvm_fd;
 extern int g_kvm_vm_fd;
 extern int g_kvm_vcpu_fd;
 
-extern uint64_t g_apic_base;
-extern uint8_t g_apic_tpr;
-
 extern int g_handling_kvm_cb;
 
 struct se_libcpu_interface_t;

--- a/src/s2e-kvm-io.c
+++ b/src/s2e-kvm-io.c
@@ -48,11 +48,11 @@ uint64_t s2e_kvm_mmio_read(target_phys_addr_t addr, unsigned size) {
     // of the TPR, which may confuse the guest.
     // Note that in 64-bit mode, guests should wither use cr8 or
     // MMIO, but not both, so we should still be consistent.
-    if ((addr >> TARGET_PAGE_BITS) == (g_apic_base >> TARGET_PAGE_BITS)) {
+    if ((addr >> TARGET_PAGE_BITS) == (env->v_apic_base >> TARGET_PAGE_BITS)) {
         if ((addr & 0xfff) == 0x80) {
             if (!(env->hflags & HF_LMA_MASK)) {
-                assert((g_apic_tpr & 0xf0) == (ret & 0xf0));
-                ret |= g_apic_tpr & 0x3;
+                assert((env->v_apic_tpr & 0xf0) == (ret & 0xf0));
+                ret |= env->v_apic_tpr & 0x3;
             }
         }
     }
@@ -110,10 +110,10 @@ void s2e_kvm_mmio_write(target_phys_addr_t addr, uint64_t data, unsigned size) {
             assert(false && "Can't get here");
     }
 
-    if ((addr >> TARGET_PAGE_BITS) == (g_apic_base >> TARGET_PAGE_BITS)) {
+    if ((addr >> TARGET_PAGE_BITS) == (env->v_apic_base >> TARGET_PAGE_BITS)) {
         if ((addr & 0xfff) == 0x80) {
-            g_apic_tpr = (uint8_t) data;
-            env->v_tpr = g_apic_tpr >> 4;
+            env->v_apic_tpr = (uint8_t) data;
+            env->v_tpr = env->v_apic_tpr >> 4;
         }
     }
 

--- a/src/s2e-kvm-libcpu-stubs.c
+++ b/src/s2e-kvm-libcpu-stubs.c
@@ -51,11 +51,11 @@ void cpu_set_apic_tpr(DeviceState *d, uint8_t val) {
 }
 
 void cpu_set_apic_base(DeviceState *d, uint64_t val) {
-    g_apic_base = val;
+    env->v_apic_base = val;
 }
 
 uint64_t cpu_get_apic_base(DeviceState *d) {
-    return g_apic_base;
+    return env->v_apic_base;
 }
 
 void cpu_set_ferr(CPUX86State *s) {

--- a/src/s2e-kvm-state.c
+++ b/src/s2e-kvm-state.c
@@ -274,10 +274,10 @@ int s2e_kvm_vcpu_set_sregs(int vcpu_fd, struct kvm_sregs *sregs) {
     env->cr[3] = sregs->cr3;
     env->cr[4] = sregs->cr4;
     env->v_tpr = sregs->cr8;
-    g_apic_tpr = sregs->cr8 << 4;
+    env->v_apic_tpr = sregs->cr8 << 4;
 
     if (sregs->apic_base) {
-        g_apic_base = sregs->apic_base;
+        env->v_apic_base = sregs->apic_base;
     }
 
     env->efer = sregs->efer;
@@ -417,7 +417,7 @@ int s2e_kvm_vcpu_get_sregs(int vcpu_fd, struct kvm_sregs *sregs) {
     sregs->cr4 = env->cr[4];
     sregs->cr8 = env->v_tpr;
 
-    sregs->apic_base = g_apic_base;
+    sregs->apic_base = env->v_apic_base;
     sregs->cr8 = env->v_tpr;
 
     sregs->efer = env->efer;


### PR DESCRIPTION
Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>